### PR TITLE
fix Azure environment (use .body instead of .rawBody)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following environments are known to be compatible:
 - [Node.js](https://nodejs.org) versions 10, 12, 13 and 14. It works in Node 8 even though the unit tests fail.
 - [AWS Lambda](https://aws.amazon.com/lambda/). [Reported](https://github.com/flash-oss/graphql-upload-minimal/issues/4#issuecomment-664234726) to be working.
 - [Google Cloud Functions (GCF)](https://cloud.google.com/functions) Experimental. Untested.
-- [Azure Functions](https://azure.microsoft.com/en-us/services/functions/) Experimental. Untested.
+- [Azure Functions](https://azure.microsoft.com/en-us/services/functions/) Working.
 - [Koa](https://koajs.com)
 - [Express.js](https://expressjs.com)
 
@@ -167,7 +167,7 @@ exports.uploadFile = function (req, res) {
 
 ### Azure Functions
 
-Possible example. Experimental. Untested.
+Possible example. Working.
 
 ```js
 const { processRequest } = require("graphql-upload-minimal");

--- a/public/processRequest.js
+++ b/public/processRequest.js
@@ -93,10 +93,10 @@ module.exports = async function processRequest(
   } else if (environment === "azure") {
     // Azure Functions compatibility
     req = req.req || res;
-    if (!req || !req.rawBody)
+    if (!req || !req.body)
       throw new HttpError(
         400,
-        "Azure Function req.rawBody is missing. See this page for more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node"
+        "Azure Function req.body is missing. See this page for more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node"
       );
   } else {
     // Regular node.js environment where request is a ReadableStream instance.
@@ -387,10 +387,10 @@ module.exports = async function processRequest(
       req.removeListener("close", abort);
     });
 
-    if (environment === "gcf" || environment === "azure") {
+    if (environment === "gcf") {
       parser.end(req.rawBody);
       release(); // the response was released by the cloud earlier, somewhere at the Gateway level.
-    } else if (environment === "lambda") {
+    } else if (environment === "lambda" || environment === "azure") {
       parser.end(req.body);
       release(); // the response was released by the cloud earlier, somewhere at the Gateway level.
     } else {

--- a/test/public/processRequest.serverless.test.js
+++ b/test/public/processRequest.serverless.test.js
@@ -61,7 +61,7 @@ describe("processRequest serverless", () => {
       );
     });
 
-    it("should throw if Azure request has no .rawBody", async () => {
+    it("should throw if Azure request has no .body", async () => {
       const badRequest = (message) => ({
         name: "BadRequestError",
         message,
@@ -76,7 +76,7 @@ describe("processRequest serverless", () => {
           { environment: "azure" }
         ),
         badRequest(
-          "Azure Function req.rawBody is missing. See this page for more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node"
+          "Azure Function req.body is missing. See this page for more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node"
         )
       );
       await rejects(
@@ -84,14 +84,14 @@ describe("processRequest serverless", () => {
           {
             req: {
               headers: { "content-type": "multipart/form-data;" },
-              rawBody: null,
+              body: null,
             },
           },
           {},
           { environment: "azure" }
         ),
         badRequest(
-          "Azure Function req.rawBody is missing. See this page for more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node"
+          "Azure Function req.body is missing. See this page for more info: https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node"
         )
       );
     });
@@ -231,7 +231,7 @@ describe("processRequest serverless", () => {
 
       // Create a fake request
       const req = {
-        rawBody: body.getBuffer(),
+        body: body.getBuffer(),
         headers: body.getHeaders(),
       };
       const context = { req };
@@ -265,7 +265,7 @@ describe("processRequest serverless", () => {
 
       // Create a fake request
       const req = {
-        rawBody: body.getBuffer(),
+        body: body.getBuffer(),
         headers: body.getHeaders(),
       };
       const context = {};


### PR DESCRIPTION
Fixes #9 and @karladler 's final remark in #3.

* fix Azure environment (use .body instead of .rawBody)
* mark Azure as working (confirmed)
* update unit tests