### PR TITLE
Add fieldName to the returned file object in processRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ type Mutations {
 GraphQL resolvers:
 
 ```js
-const { S3 } = require("aws-sdk"); 
+const { S3 } = require("aws-sdk");
 
 const resolvers = {
   Upload: require("graphql-upload-minimal").GraphQLUpload,
@@ -122,7 +122,7 @@ const resolvers = {
         const s3 = new S3({ apiVersion: "2006-03-01", params: { Bucket: "my-bucket" } });
 
         for (const doc of docs) {
-          const { createReadStream, filename /*, mimetype, encoding */ } = await doc.file;
+          const { createReadStream, filename /*, fieldName, mimetype, encoding */ } = await doc.file;
           const Key = `${ctx.user.id}/${doc.docType}-${filename}`;
           await s3.upload({ Key, Body: createReadStream() }).promise();
         }
@@ -174,6 +174,59 @@ const { processRequest } = require("graphql-upload-minimal");
 
 exports.uploadFile = function (context, req) {
   return processRequest(context, req, { environment: "azure" });
+};
+```
+
+### Uploading multiple files
+
+When uploading multiple files you can make use of the `fieldName` property to keep track of an identifier of the uploaded files. The fieldName is equal to the passed `name` property of the file in the `multipart/form-data` request. This can be modified to contain an identifier (like a UUID), for example using the `formDataAppendFile` in the commonly used [`apollo-upload-link`](https://github.com/jaydenseric/apollo-upload-client#function-formdataappendfile) library.
+
+GraphQL schema:
+
+```graphql
+scalar Upload
+input DocumentUploadInput {
+  docType: String!
+  files: [Upload!]
+}
+
+type SuccessResult {
+  success: Boolean!
+  message: String
+}
+type Mutations {
+  uploadDocuments(docs: [DocumentUploadInput!]!): SuccessResult
+}
+```
+
+GraphQL resolvers:
+
+```js
+const { S3 } = require("aws-sdk");
+
+const resolvers = {
+  Upload: require("graphql-upload-minimal").GraphQLUpload,
+
+  Mutations: {
+    async uploadDocuments(root, { docs }, ctx) {
+      try {
+        const s3 = new S3({ apiVersion: "2006-03-01", params: { Bucket: "my-bucket" } });
+
+        for (const doc of docs) {
+          // fieldName contains the "name" property from the multipart/form-data request.
+          // Use it to pass an identifier in order to store the file in a consistent manner.
+          const { createReadStream, filename, fieldName, /*, mimetype, encoding */ } = await doc.file;
+          const Key = `${ctx.user.id}/${doc.docType}-${fieldName}`;
+          await s3.upload({ Key, Body: createReadStream() }).promise();
+        }
+
+        return { success: true };
+      } catch (error) {
+        console.log("File upload failed", error);
+        return { success: false, message: error.message };
+      }
+    }
+  }
 };
 ```
 
@@ -275,7 +328,7 @@ _A manually constructed schema with an image upload mutation._
 >           },
 >         },
 >         async resolve(parent, { image }) {
->           const { filename, mimetype, createReadStream } = await image;
+>           const { filename, fieldName, mimetype, createReadStream } = await image;
 >           const stream = createReadStream();
 >           // Promisify the stream and store the file, then…
 >           return true;
@@ -516,6 +569,7 @@ has begun streaming in.
 | Property           | Type                                                           | Description                                                                                                                                         |
 | :----------------- | :------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `filename`         | string                                                         | File name.                                                                                                                                          |
+| `fieldName`        | string                                                         | The name of the field passed to the multipart/form-data request.                                                                                    |
 | `mimetype`         | string                                                         | File MIME type. Provided by the client and can't be trusted.                                                                                        |
 | `encoding`         | string                                                         | File stream transfer encoding.                                                                                                                      |
 | `createReadStream` | [FileUploadCreateReadStream](#type-fileuploadcreatereadstream) | Creates a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_readable_streams) of the file's contents, for processing and storage. |

--- a/public/index.js
+++ b/public/index.js
@@ -12,6 +12,7 @@ exports.Upload = require("./Upload");
  * @name FileUpload
  * @type {object}
  * @prop {string} filename File name.
+ * @prop {string} fieldName The name of the field passed to the multipart/form-data request.
  * @prop {string} mimetype File MIME type. Provided by the client and can't be trusted.
  * @prop {string} encoding File stream transfer encoding.
  * @prop {FileUploadCreateReadStream} createReadStream Creates a [Node.js readable stream](https://nodejs.org/api/stream.html#stream_readable_streams) of the file's contents, for processing and storage.

--- a/public/processRequest.js
+++ b/public/processRequest.js
@@ -302,6 +302,7 @@ module.exports = async function processRequest(
       });
 
       const file = {
+        fieldName,
         filename,
         mimetype,
         encoding,

--- a/test/public/processRequest.test.js
+++ b/test/public/processRequest.test.js
@@ -38,6 +38,7 @@ describe("processRequest", () => {
         const upload = await operation.variables.input.docs[0].file.promise;
 
         strictEqual(upload.filename, "a.txt");
+        strictEqual(upload.fieldName, "1");
         strictEqual(upload.mimetype, "text/plain");
         strictEqual(upload.encoding, "7bit");
 
@@ -91,6 +92,7 @@ describe("processRequest", () => {
         const upload = await operation.variables.file.promise;
 
         strictEqual(upload.filename, "a.txt");
+        strictEqual(upload.fieldName, "1");
         strictEqual(upload.mimetype, "text/plain");
         strictEqual(upload.encoding, "7bit");
 
@@ -136,6 +138,7 @@ describe("processRequest", () => {
         const uploadA = await operations[0].variables.file.promise;
 
         strictEqual(uploadA.filename, "a.txt");
+        strictEqual(uploadA.fieldName, "1");
         strictEqual(uploadA.mimetype, "text/plain");
         strictEqual(uploadA.encoding, "7bit");
 
@@ -149,6 +152,7 @@ describe("processRequest", () => {
         const uploadB = await operations[1].variables.file.promise;
 
         strictEqual(uploadB.filename, "b.txt");
+        strictEqual(uploadB.fieldName, "2");
         strictEqual(uploadB.mimetype, "text/plain");
         strictEqual(uploadB.encoding, "7bit");
 
@@ -208,6 +212,7 @@ describe("processRequest", () => {
 
         strictEqual(upload1, upload2);
         strictEqual(upload1.filename, "a.txt");
+        strictEqual(upload1.fieldName, "1");
         strictEqual(upload1.mimetype, "text/plain");
         strictEqual(upload1.encoding, "7bit");
 
@@ -308,6 +313,7 @@ describe("processRequest", () => {
         const upload = await operation.variables.file.promise;
 
         strictEqual(upload.filename, "a.txt");
+        strictEqual(upload.fieldName, "1");
         strictEqual(upload.mimetype, "text/plain");
         strictEqual(upload.encoding, "7bit");
 
@@ -436,6 +442,7 @@ describe("processRequest", () => {
         const uploadA = await operation.variables.files[0].promise;
 
         strictEqual(uploadA.filename, "a.txt");
+        strictEqual(uploadA.fieldName, "1");
         strictEqual(uploadA.mimetype, "text/plain");
         strictEqual(uploadA.encoding, "7bit");
 
@@ -515,6 +522,7 @@ describe("processRequest", () => {
         const uploadB = await operation.variables.files[1].promise;
 
         strictEqual(uploadB.filename, "b.txt");
+        strictEqual(uploadB.fieldName, "2");
         strictEqual(uploadB.mimetype, "text/plain");
         strictEqual(uploadB.encoding, "7bit");
 
@@ -624,6 +632,7 @@ describe("processRequest", () => {
           const upload = await operation.variables.fileA.promise;
 
           strictEqual(upload.filename, "a.txt");
+          strictEqual(upload.fieldName, "1");
           strictEqual(upload.mimetype, "text/plain");
           strictEqual(upload.encoding, "7bit");
 
@@ -639,6 +648,7 @@ describe("processRequest", () => {
           const upload = await operation.variables.fileB.promise;
 
           strictEqual(upload.filename, "b.txt");
+          strictEqual(upload.fieldName, "2");
           strictEqual(upload.mimetype, "text/plain");
           strictEqual(upload.encoding, "7bit");
 
@@ -760,6 +770,7 @@ describe("processRequest", () => {
           const upload = await operation.variables.fileA.promise;
 
           strictEqual(upload.filename, "a.txt");
+          strictEqual(upload.fieldName, "1");
           strictEqual(upload.mimetype, "text/plain");
           strictEqual(upload.encoding, "7bit");
 
@@ -777,6 +788,7 @@ describe("processRequest", () => {
           const upload = await operation.variables.fileB.promise;
 
           strictEqual(upload.filename, "b.txt");
+          strictEqual(upload.fieldName, "2");
           strictEqual(upload.mimetype, "text/plain");
           strictEqual(upload.encoding, "7bit");
           throws(() => upload.createReadStream(), {


### PR DESCRIPTION
When processing a dynamic list of files with corresponding ID's in a GraphQL resolver the filename is not sufficient for determining the reference. This PR adds the `fieldName` property to the returned file object which can be used to assign arbitrary identifiers from the GraphQL query/mutation. This comes in handy when you have a dynamic schema of expected files which can't be expressed using a static GraphQL query. An example (my personal use case) is a user-generated registration form with an arbitrary amount of upload fields.

Example query (multipart form-data):
- operations: `{"query":"mutation UserUploadImage($files: [Upload!]!) { UploadImage(files: $files) }", "variables": { "files": [] }}`
- map: `{"some-id": ["variables.files.0"], "another-id": ["variables.files.1"]}`
- some-id: `File`
- another-id: `File`

Example GraphQL resolver:
```javascript
async function uploadFile(file) {
	return new Promise(async (resolve, reject) => {
		const { createReadStream, fieldName } = await file;

		const id = fieldName;

		const stream = createReadStream();
		const out = require('fs').createWriteStream(id);

		stream.pipe(out);

		out.on('finish', () => {
			resolve({ id });
		});

		out.on('error', (error) => {
			reject(error);
		});
	});
}

export async function resolve(_parent, { files }, _ctx) {
	// Upload all files, return an array of objects including identifiers (fieldName)
	const uploads = await Promise.all(files.map(uploadFile));

	// Example DB call which stores references to the files using the identifier (fieldName)
	await db.user.update({
		data: {
			uploads
		}
	});

	return true;
}
```