### PR TITLE
Avoid using type declaration file in import

### DIFF
--- a/public/index.d.ts
+++ b/public/index.d.ts
@@ -2,8 +2,8 @@ import { IncomingMessage, ServerResponse } from "http";
 import { GraphQLScalarType } from "graphql";
 import { ReadStream } from "fs";
 
-import { RequestHandler } from "@types/express";
-import { DefaultContext, DefaultState, Middleware } from "@types/koa";
+import { RequestHandler } from "express";
+import { DefaultContext, DefaultState, Middleware } from "koa";
 
 export interface UploadOptions {
   maxFieldSize?: number | undefined;

--- a/public/index.d.ts
+++ b/public/index.d.ts
@@ -2,8 +2,8 @@ import { IncomingMessage, ServerResponse } from "http";
 import { GraphQLScalarType } from "graphql";
 import { ReadStream } from "fs";
 
-import { RequestHandler } from "express";
-import { DefaultContext, DefaultState, Middleware } from "koa";
+import type { RequestHandler } from "express";
+import type { DefaultContext, DefaultState, Middleware } from "koa";
 
 export interface UploadOptions {
   maxFieldSize?: number | undefined;


### PR DESCRIPTION
This commit fixes an error whilst compiling my TS project 🎉.
Hopefully others can benefit from this fix as well.

It is advised to not import `@types/<package>` directly, as the error message mentions.

Command in my pipeline: `npx tsc --outDir dist`

```
❯ npx tsc --outDir dist
node_modules/graphql-upload-minimal/public/index.d.ts:5:32 - error TS6137: Cannot import type declaration files. Consider importing 'express' instead of '@types/express'.

5 import { RequestHandler } from "@types/express";
                                 ~~~~~~~~~~~~~~~~

node_modules/graphql-upload-minimal/public/index.d.ts:6:58 - error TS2307: Cannot find module '@types/koa' or its corresponding type declarations.

6 import { DefaultContext, DefaultState, Middleware } from "@types/koa";
                                                           ~~~~~~~~~~~~

node_modules/graphql-upload-minimal/public/index.d.ts:6:58 - error TS6137: Cannot import type declaration files. Consider importing 'koa' instead of '@types/koa'.

6 import { DefaultContext, DefaultState, Middleware } from "@types/koa";
                                                           ~~~~~~~~~~~~


Found 3 errors in the same file, starting at: node_modules/graphql-upload-minimal/public/index.d.ts:5
```