### PR TITLE
Update resolver example

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const resolvers = {
         const s3 = new S3({ apiVersion: "2006-03-01", params: { Bucket: "my-bucket" } });
 
         for (const doc of docs) {
-          const { createReadStream, filename /*, fieldName, mimetype, encoding */ } = await doc.file;
+          const { createReadStream, filename /*, fieldName, mimetype, encoding */ } = await doc.promise;
           const Key = `${ctx.user.id}/${doc.docType}-${filename}`;
           await s3.upload({ Key, Body: createReadStream() }).promise();
         }


### PR DESCRIPTION
A resolver should await the `promise` field instead ([type definition](https://github.com/tanakaworld/graphql-upload-minimal/blob/3f0610174586e029cb804ca1f011b7816b1b3add/public/index.d.ts#L38)). Otherwise, the resolver may not be able to manipulate the file properly.

