### PR TITLE
Fix TypeScript import from an ESM codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "main": "public",
   "exports": {
     ".": {
+      "types": "./public/index.d.ts",
       "import": "./public/index.mjs",
       "require": "./public/index.js"
     },


### PR DESCRIPTION
We recently converted our codebase from CommonJS (CJS) to ESModules (ESM), by adding `type: "module"` to our `package.json`.

We use TypeScript, and all our imports from `graphql-upload-minimal` then started failing, with this error message:

```
Could not find a declaration file for module 'graphql-upload-minimal'. '.../node_modules/graphql-upload-minimal/public/index.mjs' implicitly has an 'any' type.
  There are types at '.../node_modules/graphql-upload-minimal/public/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'graphql-upload-minimal' library may need to update its package.json or typings.ts(7016)
```

I found this Stack Overflow post about this:

https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts

Which suggests that you may simply need to move your `types` declaration in your `package.json` into `exports`.

I did that in a local pnpm patch for us, and that fixes this in our codebase!

So opening this PR with that change, if helpful for others, but not sure if this change is 100% safe for all other setups too.

Thank you for your library!