### PR TITLE
fix(#51): stream emits error when stream triggers limit

### DIFF
--- a/public/processRequest.js
+++ b/public/processRequest.js
@@ -269,6 +269,7 @@ module.exports = async function processRequest(
             stream.on("limit", () => {
                 fileError = new HttpError(413, `File truncated as it exceeds the ${maxFileSize} byte size limit.`);
                 stream.unpipe();
+                stream.emit("error", fileError);
             });
 
             stream.on("error", (error) => {


### PR DESCRIPTION
In #51 , we found the stream triggers only a `limit` event when the file size exceeds the limit.

We want to emit an error event to make people can catch it on 'error'.